### PR TITLE
Combined: 7 Dependabot dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6741,9 +6741,9 @@
       "integrity": "sha512-D0ZXfNkS3z9GO+Ha2rC2odvOOMcx/moL8lpVDFxXqcsCEZbJimuki4wZfdrQrGlNd/d7r4DNodljRmO20v6Ntg=="
     },
     "core-js": {
-      "version": "3.22.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.7.tgz",
-      "integrity": "sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg=="
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.0.tgz",
+      "integrity": "sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw=="
     },
     "core-js-compat": {
       "version": "3.31.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6657,9 +6657,9 @@
       "dev": true
     },
     "cordova-plugin-splashscreen": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-splashscreen/-/cordova-plugin-splashscreen-6.0.1.tgz",
-      "integrity": "sha512-olJPBFRUuzunzeuB76TOBoq3yYlnhpWDk/S7ErR6MdqPz1KuK36omB9u4o//SdgfBbxHz+SsUtyvst68NrU3pA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-splashscreen/-/cordova-plugin-splashscreen-6.0.2.tgz",
+      "integrity": "sha512-7JiUfnInir+SCOEgTJ+5/cHF3UFl69jp6cAQfHtJaaQt9Pli8D8yTJjU0HGlJCvryvsVs4Xlc7/sEJM7vLJgvg==",
       "dev": true
     },
     "cordova-plugin-statusbar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15502,9 +15502,12 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.9.1.tgz",
-      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag=="
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.4.tgz",
+      "integrity": "sha512-NtTUvIlNELez7Q1DzKVIFZBzNb646boQMgpATo9z3Ftuu/gWvzxCW7jdjcUDoRGxRikrhVHB/zLXh1hxeJawvw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6618,9 +6618,9 @@
       }
     },
     "cordova-plugin-device": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-2.0.3.tgz",
-      "integrity": "sha512-Jb3V72btxf3XHpkPQsGdyc8N6tVBYn1vsxSFj43fIz9vonJDUThYPCJJHqk6PX6N4dJw6I4FjxkpfCR4LDYMlw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-2.1.0.tgz",
+      "integrity": "sha512-FU0Lw1jZpuKOgG4v80LrfMAOIMCGfAVPumn7AwaX9S1iU/X3OPZUyoKUgP09q4bxL35IeNPkqNWVKYduAXZ1sg==",
       "dev": true
     },
     "cordova-plugin-ionic-keyboard": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4659,9 +4659,9 @@
       }
     },
     "@types/underscore": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz",
-      "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==",
+      "version": "1.11.15",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.15.tgz",
+      "integrity": "sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==",
       "dev": true
     },
     "@types/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8303,9 +8303,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true
     },
     "for-in": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10126,20 +10126,12 @@
       }
     },
     "karma-jasmine": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-4.0.1.tgz",
-      "integrity": "sha512-h8XDAhTiZjJKzfkoO1laMH+zfNlra+dEQHUAjpn5JV1zCPtOIVWGQjLBrqhnzQa/hrU2XrZwSyBa6XjEBzfXzw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
+      "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
       "requires": {
-        "jasmine-core": "^3.6.0"
-      },
-      "dependencies": {
-        "jasmine-core": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.7.1.tgz",
-          "integrity": "sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==",
-          "dev": true
-        }
+        "jasmine-core": "^4.1.0"
       }
     },
     "karma-jasmine-html-reporter": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rxjs": "^6.5.4",
     "sharp": "^0.32.6",
     "tslib": "^2.5.3",
-    "zone.js": "~0.9.1"
+    "zone.js": "~0.14.4"
   },
   "devDependencies": {
     "@angular-devkit/architect": "~0.1700.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/node": "~18.15.11",
     "@types/underscore": "^1.11.4",
     "codelyzer": "^6.0.2",
-    "cordova-plugin-device": "^2.0.3",
+    "cordova-plugin-device": "^2.1.0",
     "cordova-plugin-ionic-keyboard": "^2.2.0",
     "cordova-plugin-ionic-webview": "^5.0.0",
     "cordova-plugin-splashscreen": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/jasmine": "~5.1.2",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~18.15.11",
-    "@types/underscore": "^1.11.4",
+    "@types/underscore": "^1.11.15",
     "codelyzer": "^6.0.2",
     "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-ionic-keyboard": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cordova-android": "^10.1.2",
     "cordova-browser": "^7.0.0",
     "cordova-sqlite-storage": "^6.1.0",
-    "core-js": "^3.22.7",
+    "core-js": "^3.36.0",
     "firebase": "^9.23.0",
     "ngx-qrcode2": "9.0.0",
     "phonegap-plugin-barcodescanner": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "karma": "~6.3.20",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage-istanbul-reporter": "~3.0.3",
-    "karma-jasmine": "~4.0.1",
+    "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^1.7.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-ionic-keyboard": "^2.2.0",
     "cordova-plugin-ionic-webview": "^5.0.0",
-    "cordova-plugin-splashscreen": "^6.0.1",
+    "cordova-plugin-splashscreen": "^6.0.2",
     "cordova-plugin-statusbar": "^3.0.0",
     "cordova-plugin-whitelist": "^1.3.5",
     "jasmine-spec-reporter": "~7.0.0",


### PR DESCRIPTION
Combined Dependabot dependency updates (7 PRs):

- Bump core-js from 3.22.7 to 3.36.0 (#437)
- Bump zone.js from 0.9.1 to 0.14.4 (#436)
- Bump follow-redirects from 1.15.1 to 1.15.4 (#434)
- Bump @types/underscore from 1.11.4 to 1.11.15 (#430)
- Bump cordova-plugin-device from 2.0.3 to 2.1.0 (#426)
- Bump karma-jasmine from 4.0.1 to 5.1.0 (#421)
- Bump cordova-plugin-splashscreen from 6.0.1 to 6.0.2 (#420)

This PR combines all open Dependabot updates to verify CI passes before merging.